### PR TITLE
Template processes only run when a template is provided

### DIFF
--- a/bin/template_reference.R
+++ b/bin/template_reference.R
@@ -106,7 +106,9 @@ option_list = list(
     make_option(c("-r", "--reference"), type="character", default=NULL,
         help="Reference fasta file", metavar="character"),
     make_option(c("-t", "--template"), type="character", default=NULL,
-        help="Temporary folder", metavar="character")
+        help="Temporary folder", metavar="character"),
+    make_option(c("-p", "--prefix"), type="character", default=NULL,
+        help="Sample prefix", metavar="character")
 );
 
 opt_parser = OptionParser(option_list=option_list);
@@ -114,6 +116,7 @@ opt = parse_args(opt_parser);
 
 ref_fasta = opt$reference
 temp = opt$template
+prefix = opt$prefix
 
 ### Get template and reference sequences from fasta files
 temp_seq <- sread(readFasta(temp))[[1]]
@@ -121,4 +124,4 @@ ref_seq <- sread(readFasta(ref_fasta))[[1]]
 
 ### Generate new reference (reference with change done by the template)
 NewRef <- newReference(temp_seq, ref_seq)
-write.fasta(NewRef, "reference_template", file.out = "NewRef.fasta")
+write.fasta(NewRef, "reference_template", file.out = paste(prefix, "NewReference.fasta", sep="_"))

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -28,7 +28,7 @@ process {
 
     withName: SEQ_TO_FILE_REF {
         publishDir = [
-            path: { "${params.outdir}/" },
+            path: { "${params.outdir}/preprocessing/sequences" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/docs/output.md
+++ b/docs/output.md
@@ -39,7 +39,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
   - `*_reference.fasta`: Sequence used as a reference.
   - `*_template.fasta`: Provided template sequence.
   - `*_correctOrient.fasta`: Reference sequence in the correct orientation.
-  - `NewRef.fasta`: New reference generated from adding the changes made by the template to the original reference.
+  - `_NewReference.fasta`: New reference generated from adding the changes made by the template to the original reference.
   - `*_template-align.bam`: Alignment of the new reference (with template changes) to the original reference.
 
 </details>

--- a/modules/local/seq_to_file.nf
+++ b/modules/local/seq_to_file.nf
@@ -15,6 +15,9 @@ process SEQ_TO_FILE {
     tuple val(meta), path('*.fasta') , emit: file
     path "versions.yml"              , emit: versions
 
+    when:
+    sequence != null
+
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/modules/local/template_reference.nf
+++ b/modules/local/template_reference.nf
@@ -25,6 +25,7 @@ process TEMPLATE_REFERENCE {
         $args \\
         --reference=$reference \\
         --template=$template \\
+        --prefix=$prefix
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":


### PR DESCRIPTION
Fix template processes. They only run when a template is provided. 
This will hopefully make AWS test run finish successfully.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/crisprseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/crisprseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
