### PR TITLE
alias all includes of MINIMAP2_ALIGN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix warning "module used more than once"
+- Fix warning "module used more than once" ([#25](https://github.com/nf-core/crisprseq/pull/25))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix warning "module used more than once"
+
 ### Dependencies
 
 ### Deprecated

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -131,7 +131,7 @@ process {
         ]
     }
 
-    withName: MINIMAP2_ALIGN {
+    withName: MINIMAP2_ALIGN_ORIGINAL {
         ext.args = '-A 29 -B 17 -O 25 -E 2'
     }
 

--- a/workflows/crisprseq.nf
+++ b/workflows/crisprseq.nf
@@ -72,7 +72,7 @@ include { BOWTIE2_ALIGN                                 } from '../modules/nf-co
 include { BOWTIE2_BUILD                                 } from '../modules/nf-core/bowtie2/build/main'
 include { BWA_MEM                                       } from '../modules/nf-core/bwa/mem/main'
 include { BWA_INDEX                                     } from '../modules/nf-core/bwa/index/main'
-include { MINIMAP2_ALIGN                                } from '../modules/nf-core/minimap2/align/main'
+include { MINIMAP2_ALIGN as MINIMAP2_ALIGN_ORIGINAL     } from '../modules/nf-core/minimap2/align/main'
 include { MINIMAP2_ALIGN as MINIMAP2_ALIGN_TEMPLATE     } from '../modules/nf-core/minimap2/align/main'
 include { CUTADAPT                                      } from '../modules/nf-core/cutadapt/main'
 include { SAMTOOLS_INDEX                                } from '../modules/nf-core/samtools/index/main'
@@ -309,15 +309,15 @@ workflow CRISPRSEQ {
     // MODULE: Mapping with Minimap2
     //
     if (params.aligner == "minimap2") {
-        MINIMAP2_ALIGN (
+        MINIMAP2_ALIGN_ORIGINAL (
             SEQTK_SEQ.out.fastx
                 .join(ORIENT_REFERENCE.out.reference),
             true,
             false,
             true
         )
-        ch_mapped_bam = MINIMAP2_ALIGN.out.bam
-        ch_versions = ch_versions.mix(MINIMAP2_ALIGN.out.versions)
+        ch_mapped_bam = MINIMAP2_ALIGN_ORIGINAL.out.bam
+        ch_versions = ch_versions.mix(MINIMAP2_ALIGN_ORIGINAL.out.versions)
     }
 
     //


### PR DESCRIPTION
The warning indicating that a module was included twice was due to using a module without an alias and the same one with an alias.
Aliasing all include statements of this module should fix the warning.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/crisprseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/crisprseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
