### PR TITLE
Split AWS fulltests in two separate files

### DIFF
--- a/.github/workflows/awsfulltest_screening.yml
+++ b/.github/workflows/awsfulltest_screening.yml
@@ -1,4 +1,4 @@
-name: nf-core AWS full size tests targeted
+name: nf-core AWS full size tests screening
 # This workflow is triggered on published releases.
 # It can be additionally triggered manually with GitHub actions workflow dispatch button.
 # It runs the -profile 'test_full' on AWS batch
@@ -19,12 +19,12 @@ jobs:
           workspace_id: ${{ secrets.TOWER_WORKSPACE_ID }}
           access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}
           compute_env: ${{ secrets.TOWER_COMPUTE_ENV }}
-          workdir: s3://${{ secrets.AWS_S3_BUCKET }}/work/crisprseq/work-${{ github.sha }}/targeted_test
+          workdir: s3://${{ secrets.AWS_S3_BUCKET }}/work/crisprseq/work-${{ github.sha }}/screening_test
           parameters: |
             {
-              "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/crisprseq/results-${{ github.sha }}/targeted_test"
+              "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/crisprseq/results-${{ github.sha }}/screening_test"
             }
-          profiles: test_full,aws_tower
+          profiles: test_screening_full,aws_tower
       - uses: actions/upload-artifact@v3
         with:
           name: Tower debug log file


### PR DESCRIPTION
Following [Sarek](https://github.com/nf-core/sarek/blob/master/.github/workflows/awsfulltest_germline.yml) as an example, split AWS full tests in two separate files / GHA workflows.
This way we can trigger both independently.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/crisprseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/crisprseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
