### PR TITLE
remove profile aws_tower

### DIFF
--- a/.github/workflows/awsfulltest.yml
+++ b/.github/workflows/awsfulltest.yml
@@ -24,7 +24,7 @@ jobs:
             {
               "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/crisprseq/results-${{ github.sha }}/targeted_test"
             }
-          profiles: test_full,aws_tower
+          profiles: test_full
       - uses: actions/upload-artifact@v3
         with:
           name: Tower debug log file

--- a/.github/workflows/awsfulltest_screening.yml
+++ b/.github/workflows/awsfulltest_screening.yml
@@ -24,7 +24,7 @@ jobs:
             {
               "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/crisprseq/results-${{ github.sha }}/screening_test"
             }
-          profiles: test_screening_full,aws_tower
+          profiles: test_screening_full
       - uses: actions/upload-artifact@v3
         with:
           name: Tower debug log file

--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -22,7 +22,7 @@ jobs:
             {
               "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/crisprseq/results-test-${{ github.sha }}"
             }
-          profiles: test,aws_tower
+          profiles: test
       - uses: actions/upload-artifact@v3
         with:
           name: Tower debug log file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         NXF_VER:
-          - "22.10.1"
+          - "23.04.0"
           - "latest-everything"
         ANALYSIS:
           - "test_screening"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix warning "module used more than once" ([#25](https://github.com/nf-core/crisprseq/pull/25))
 - Remove profile `aws_tower`, update from nf-core/tools v2.9 to make full tests pass ([#50](https://github.com/nf-core/crisprseq/pull/50))
+- Remove `quay.io` from all containers ([#50](https://github.com/nf-core/crisprseq/pull/50))
 
 ## [v1.0 - Salted Hypatia](https://github.com/nf-core/crisprseq/releases/tag/1.0) - [02.02.2023]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix warning "module used more than once" ([#25](https://github.com/nf-core/crisprseq/pull/25))
+- Remove profile `aws_tower`, update from nf-core/tools v2.9 to make full tests pass ([#50](https://github.com/nf-core/crisprseq/pull/50))
 
 ## [v1.0 - Salted Hypatia](https://github.com/nf-core/crisprseq/releases/tag/1.0) - [02.02.2023]
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?labelColor=000000&logo=Amazon%20AWS)](https://nf-co.re/crisprseq/results)[![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.7598497-1073c8?labelColor=000000)](https://doi.org/10.5281/zenodo.7598497)
 
-[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A522.10.1-23aa62.svg)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A523.04.0-23aa62.svg)](https://www.nextflow.io/)
 [![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)
 [![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)
 [![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -10,8 +10,6 @@
 ----------------------------------------------------------------------------------------
 */
 
-cleanup = true
-
 params {
     config_profile_name        = 'Full test profile'
     config_profile_description = 'Full test dataset to check pipeline function'

--- a/modules.json
+++ b/modules.json
@@ -99,7 +99,7 @@
                     },
                     "racon": {
                         "branch": "master",
-                        "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
+                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
                         "installed_by": ["modules"]
                     },
                     "samtools/faidx": {
@@ -119,13 +119,13 @@
                     },
                     "vsearch/cluster": {
                         "branch": "master",
-                        "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
+                        "git_sha": "603ecbd9f45300c9788f197d2a15a005685b4220",
                         "installed_by": ["modules"],
                         "patch": "modules/nf-core/vsearch/cluster/vsearch-cluster.diff"
                     },
                     "vsearch/sort": {
                         "branch": "master",
-                        "git_sha": "e7801603532df26b4bb4ef324ca2c39f7a4d0eee",
+                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
                         "installed_by": ["modules"]
                     }
                 }

--- a/modules/nf-core/mageck/mle/mageck-mle.diff
+++ b/modules/nf-core/mageck/mle/mageck-mle.diff
@@ -2,7 +2,7 @@ Changes in module 'nf-core/mageck/mle'
 --- modules/nf-core/mageck/mle/main.nf
 +++ modules/nf-core/mageck/mle/main.nf
 @@ -8,8 +8,7 @@
-         'quay.io/biocontainers/mageck:0.5.9--py37h6bb024c_0' }"
+         'biocontainers/mageck:0.5.9--py37h6bb024c_0' }"
  
      input:
 -    tuple val(meta), path(count_table)

--- a/modules/nf-core/minimap2/align/minimap2-align.diff
+++ b/modules/nf-core/minimap2/align/minimap2-align.diff
@@ -2,7 +2,7 @@ Changes in module 'nf-core/minimap2/align'
 --- modules/nf-core/minimap2/align/main.nf
 +++ modules/nf-core/minimap2/align/main.nf
 @@ -9,8 +9,7 @@
-         'quay.io/biocontainers/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8-0' }"
+         'biocontainers/mulled-v2-66534bcbb7031a148b13e2ad42583020b9cd25c4:1679e915ddb9d6b4abda91880c4b48857d471bd8-0' }"
  
      input:
 -    tuple val(meta), path(reads)

--- a/modules/nf-core/racon/main.nf
+++ b/modules/nf-core/racon/main.nf
@@ -5,7 +5,7 @@ process RACON {
     conda "bioconda::racon=1.4.20"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/racon:1.4.20--h9a82719_1' :
-        'quay.io/biocontainers/racon:1.4.20--h9a82719_1' }"
+        'biocontainers/racon:1.4.20--h9a82719_1' }"
 
     input:
     tuple val(meta), path(reads), path(assembly), path(paf)

--- a/modules/nf-core/vsearch/cluster/main.nf
+++ b/modules/nf-core/vsearch/cluster/main.nf
@@ -5,7 +5,7 @@ process VSEARCH_CLUSTER {
     conda "bioconda::vsearch=2.21.1 bioconda::samtools=1.16.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/mulled-v2-53dae514294fca7b44842b784ed85a5303ac2d80:7b3365d778c690ca79bc85aaaeb86bb39a2dec69-0':
-        'quay.io/biocontainers/mulled-v2-53dae514294fca7b44842b784ed85a5303ac2d80:7b3365d778c690ca79bc85aaaeb86bb39a2dec69-0' }"
+        'biocontainers/mulled-v2-53dae514294fca7b44842b784ed85a5303ac2d80:7b3365d778c690ca79bc85aaaeb86bb39a2dec69-0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/vsearch/cluster/meta.yml
+++ b/modules/nf-core/vsearch/cluster/meta.yml
@@ -3,6 +3,7 @@ description: Cluster sequences using a single-pass, greedy centroid-based cluste
 keywords:
   - vsearch
   - clustering
+  - microbiome
 tools:
   - vsearch:
       description: VSEARCH is a versatile open-source tool for microbiome analysis, including chimera detection, clustering, dereplication and rereplication, extraction, FASTA/FASTQ/SFF file processing, masking, orienting, pair-wise alignment, restriction site cutting, searching, shuffling, sorting, subsampling, and taxonomic classification of amplicon sequences for metagenomics, genomics, and population genetics. (USEARCH alternative)

--- a/modules/nf-core/vsearch/sort/main.nf
+++ b/modules/nf-core/vsearch/sort/main.nf
@@ -5,7 +5,7 @@ process VSEARCH_SORT {
     conda "bioconda::vsearch=2.21.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/vsearch:2.21.1--h95f258a_0':
-        'quay.io/biocontainers/vsearch:2.21.1--h95f258a_0' }"
+        'biocontainers/vsearch:2.21.1--h95f258a_0' }"
 
     input:
     tuple val(meta), path(fasta)

--- a/modules/nf-core/vsearch/sort/meta.yml
+++ b/modules/nf-core/vsearch/sort/meta.yml
@@ -28,7 +28,7 @@ input:
   - sort_arg:
       type: string
       description: Argument to provide to sort algorithm. Sort by abundance with --sortbysize or by sequence length with --sortbylength.
-      enums: ["--sortbysize", "--sortbylength"]
+      enum: ["--sortbysize", "--sortbylength"]
 
 output:
   - meta:

--- a/nextflow.config
+++ b/nextflow.config
@@ -127,7 +127,6 @@ profiles {
     }
     docker {
         docker.enabled         = true
-        docker.registry        = 'quay.io'
         docker.userEmulation   = true
         conda.enabled          = false
         singularity.enabled    = false
@@ -151,7 +150,6 @@ profiles {
     }
     podman {
         podman.enabled         = true
-        podman.registry        = 'quay.io'
         conda.enabled          = false
         docker.enabled         = false
         singularity.enabled    = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -244,7 +244,7 @@ manifest {
     homePage        = 'https://github.com/nf-core/crisprseq'
     description     = """Pipeline for the analysis of crispr data"""
     mainScript      = 'main.nf'
-    nextflowVersion = '!>=22.10.1'
+    nextflowVersion = '!>=23.04.0'
     version         = '2.0.0'
     doi             = 'https://doi.org/10.5281/zenodo.7598497'
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -129,7 +129,6 @@ profiles {
         docker.enabled         = true
         docker.registry        = 'quay.io'
         docker.userEmulation   = true
-        docker.registry        = 'quay.io'
         conda.enabled          = false
         singularity.enabled    = false
         podman.enabled         = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -218,6 +218,13 @@ env {
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']
 
+// Set default registry for Docker, Singularity and Podman independent of -profile
+// Will not be used unless Docker, Singularity and Podman are enabled
+// Set to your registry if you have a mirror of containers
+docker.registry      = 'quay.io'
+podman.registry      = 'quay.io'
+singularity.registry = 'quay.io'
+
 def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 timeline {
     enabled = true


### PR DESCRIPTION
AWS full tests are failing. 
Profile `aws_tower` was removed in nf-core/tools v2.9 https://github.com/nf-core/tools/pull/2287 and https://github.com/nf-core/tools/pull/2288/files
This will hopefuly make tests pass

In addition, remove all `quay.io` from all moduels, set the registry defaults in `nextflow.config`outside of profiles and update nextflow version.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/crisprseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/crisprseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
