### PR TITLE
Run test_Targeted when using `-profile test`

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -2,4 +2,3 @@ repository_type: pipeline
 lint:
   # We skip these linting as we have splitted tests between targeted and screening
   files_exist: conf/test.config
-  actions_ci: false

--- a/lib/WorkflowMain.groovy
+++ b/lib/WorkflowMain.groovy
@@ -11,9 +11,8 @@ class WorkflowMain {
     //
     public static String citation(workflow) {
         return "If you use ${workflow.manifest.name} for your analysis please cite:\n\n" +
-            // TODO nf-core: Add Zenodo DOI for pipeline after first release
-            //"* The pipeline\n" +
-            //"  https://doi.org/10.5281/zenodo.XXXXXXX\n\n" +
+            "* The pipeline\n" +
+            "  https://doi.org/10.5281/zenodo.7598497\n\n" +
             "* The nf-core framework\n" +
             "  https://doi.org/10.1038/s41587-020-0439-x\n\n" +
             "* Software dependencies\n" +

--- a/nextflow.config
+++ b/nextflow.config
@@ -189,6 +189,7 @@ profiles {
         executor.cpus          = 16
         executor.memory        = 60.GB
     }
+    test           { includeConfig 'conf/test_targeted.config' }
     test_targeted  { includeConfig 'conf/test_targeted.config' }
     test_full      { includeConfig 'conf/test_full.config' }
     test_umis      { includeConfig 'conf/test_umis.config' }


### PR DESCRIPTION
Run test_Targeted when using `-profile test`. 
This will avoid pipeline failures if the common `-profile test` is used

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/crisprseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/crisprseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
