### PR TITLE
Fix resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Summary processes don't modify the input file anymore, allowing resuming these processes ([#65](https://github.com/nf-core/crisprseq/pull/65))
+- Summary processes don't modify the input file anymore, allowing resuming these processes ([#66](https://github.com/nf-core/crisprseq/pull/66))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Summary processes don't modify the input file anymore, allowing resuming these processes ([#65](https://github.com/nf-core/crisprseq/pull/65))
+
 ### Deprecated
 
 ## [v2.0.0 - Paprika Lovelace](https://github.com/nf-core/crisprseq/releases/tag/2.0.0) - [05.07.2023]

--- a/modules/local/alignment_summary.nf
+++ b/modules/local/alignment_summary.nf
@@ -11,7 +11,7 @@ process ALIGNMENT_SUMMARY {
     tuple val(meta), path(reads), path(summary)
 
     output:
-    tuple val(meta), path(summary), emit: summary
+    tuple val(meta), path("*_alignment_summary.csv"), emit: summary
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/clustering_summary.nf
+++ b/modules/local/clustering_summary.nf
@@ -11,7 +11,7 @@ process CLUSTERING_SUMMARY {
     tuple val(meta), path(reads), path(summary)
 
     output:
-    tuple val(meta), path(summary), emit: summary
+    tuple val(meta), path("*_clustering_summary.csv"), emit: summary
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/merging_summary.nf
+++ b/modules/local/merging_summary.nf
@@ -12,7 +12,7 @@ process MERGING_SUMMARY {
 
 
     output:
-    tuple val(meta), path("*_summary.csv"), emit: summary
+    tuple val(meta), path("*_merging_summary.csv"), emit: summary
 
     when:
     task.ext.when == null || task.ext.when

--- a/templates/alignment_summary.py
+++ b/templates/alignment_summary.py
@@ -12,7 +12,8 @@ with open("$summary", "r") as summary:
     summary_lines = summary.readlines()
 
 add_line = True
-with open("$summary", "w") as output_file:
+outname = "$summary".replace("_clustering_summary.csv", "_alignment_summary.csv")
+with open(outname, "w") as output_file:
     for line in summary_lines:
         if "aligned-reads" not in line:
             output_file.write(line)

--- a/templates/clustering_summary.py
+++ b/templates/clustering_summary.py
@@ -12,7 +12,8 @@ with open("$summary", "r") as summary:
     summary_lines = summary.readlines()
 
 add_line = True
-with open("$summary", "w") as output_file:
+outname = "$summary".replace("_merging_summary.csv", "_clustering_summary.csv")
+with open(outname, "w") as output_file:
     for line in summary_lines:
         if "clustered-reads" not in line:
             output_file.write(line)

--- a/templates/merging_summary.py
+++ b/templates/merging_summary.py
@@ -34,7 +34,7 @@ if "$task.ext.prefix" != "null":
 else:
     prefix = "$meta.id"
 
-with open(f"{prefix}_summary.csv", "w") as output_file:
+with open(f"{prefix}_merging_summary.csv", "w") as output_file:
     output_file.write("class, count\\n")
     output_file.write(f"raw-reads, {raw_reads_count} (100.0%)\\n")
     output_file.write(

--- a/workflows/crisprseq_targeted.nf
+++ b/workflows/crisprseq_targeted.nf
@@ -341,6 +341,15 @@ workflow CRISPRSEQ_TARGETED {
             .join(PEAR.out.assembled, remainder: true)
             .join(SEQTK_SEQ_MASK.out.fastx)
             .join(CUTADAPT.out.log)
+            .map { meta, reads, assembled, masked, trimmed ->
+                if (assembled == null) {
+                    assembled = file('null_a')
+                }
+                if (trimmed == "null") {
+                    trimmed = file('null_t')
+                }
+                return [ meta, reads, assembled, masked, trimmed ]
+            }
             .set { ch_merging_summary_data }
     } else {
         ch_cat_fastq.paired


### PR DESCRIPTION
Summary modules were modifying the input file. This made the resume break on these modules.
They now generate a new file instead of modifying the input, fixing the catching of these modules.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/crisprseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/crisprseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
