### PR TITLE
Don't stash unexistent files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Do not stash unexistent files, use empty lists instead. Fixes AWS tests ([#67](https://github.com/nf-core/crisprseq/pull/67))
+
 ### Deprecated
 
 ## [v2.0.0 - Paprika Lovelace](https://github.com/nf-core/crisprseq/releases/tag/2.0.0) - [05.07.2023]

--- a/templates/merging_summary.py
+++ b/templates/merging_summary.py
@@ -7,7 +7,7 @@ from Bio import SeqIO
 with gzip.open("${raw_reads[0]}", "rt") as handle:
     raw_reads_count = len(list(SeqIO.parse(handle, "fastq")))
 
-if "$assembled_reads" == "null_a":
+if "$assembled_reads" == "":
     assembled_reads_count = 0
 else:
     with gzip.open("$assembled_reads", "rt") as handle:
@@ -16,7 +16,7 @@ else:
 with gzip.open("$trimmed_reads", "rt") as handle:
     trimmed_reads_count = len(list(SeqIO.parse(handle, "fastq")))  # Filtered reads
 
-if "$trimmed_adapters" == "null_t":
+if "$trimmed_adapters" == "":
     adapters_count = 0
     adapters_percentage = "(0.0%)"
 else:
@@ -41,7 +41,7 @@ with open(f"{prefix}_summary.csv", "w") as output_file:
         f"merged-reads, {assembled_reads_count} ({round(assembled_reads_count * 100 / raw_reads_count,1)}%)\\n"
     )
     output_file.write(f"reads-with-adapters, {adapters_count} {adapters_percentage}\\n")
-    if "$assembled_reads" == "null_a":
+    if "$assembled_reads" == "":
         output_file.write(
             f"quality-filtered-reads, {trimmed_reads_count} ({round(trimmed_reads_count * 100 / raw_reads_count,1)}%)\\n"
         )

--- a/workflows/crisprseq_targeted.nf
+++ b/workflows/crisprseq_targeted.nf
@@ -341,21 +341,23 @@ workflow CRISPRSEQ_TARGETED {
             .join(PEAR.out.assembled, remainder: true)
             .join(SEQTK_SEQ_MASK.out.fastx)
             .join(CUTADAPT.out.log)
+            .map { meta, reads, assembled, masked, trimmed ->
+                if (assembled == null) {
+                    assembled = []
+                }
+                return [ meta, reads, assembled, masked, trimmed ]
+            }
             .set { ch_merging_summary_data }
     } else {
         ch_cat_fastq.paired
             .mix(ch_cat_fastq.single)
             .join(PEAR.out.assembled, remainder: true)
             .join(SEQTK_SEQ_MASK.out.fastx)
-            .combine(Channel.value("null"))
-            .map { meta, reads, assembled, masked, trimmed ->
+            .map { meta, reads, assembled, masked ->
                 if (assembled == null) {
-                    assembled = file('null_a')
+                    assembled = []
                 }
-                if (trimmed == "null") {
-                    trimmed = file('null_t')
-                }
-                return [ meta, reads, assembled, masked, trimmed ]
+                return [ meta, reads, assembled, masked, [] ]
             }
             .set { ch_merging_summary_data }
     }
@@ -705,13 +707,13 @@ workflow CRISPRSEQ_TARGETED {
         .join(ALIGNMENT_SUMMARY.out.summary)
         .map { meta, reads, index, reference, protospacer, template, template_bam, reference_template, summary ->
             if (template == null) {
-                template = file('null_t')
+                template = []
             }
             if (template_bam == null) {
-                template_bam = file('null_b')
+                template_bam = []
             }
             if (reference_template == null) {
-                reference_template = file('null_r')
+                reference_template = []
             }
             return [meta, reads, index, reference, protospacer, template, template_bam, reference_template, summary]
         }


### PR DESCRIPTION
Previously when a file was null, we were trying to stash files called "null", this files don't exist, and this broke AWS tests. Now we are using empty lists instead, the propper way to handle null or empty channels in Nextflow.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/crisprseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/crisprseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
