### PR TITLE
skip dolar signs on containerOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v2.3.0dev]
+## [v2.2.1dev]
 
 ### Added
 
 ### Fixed
 
-- Fix singularity image pull tag for MAGeCKFlute
+- Fix singularity image pull tag for MAGeCKFlute ([#160](https://github.com/nf-core/crisprseq/pull/160))
+- Skip dolar signs on containerOptions ([#163](https://github.com/nf-core/crisprseq/pull/163))
 
 ### Deprecated
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -140,10 +140,10 @@ profiles {
         shifter.enabled          = false
         charliecloud.enabled     = false
         apptainer.enabled        = false
-        process.containerOptions = '-u $(id -u):$(id -g)'
+        process.containerOptions = '-u \$(id -u):\$(id -g)'
     }
     arm {
-        process.containerOptions = '-u $(id -u):$(id -g) --platform=linux/amd64'
+        process.containerOptions = '-u \$(id -u):\$(id -g) --platform=linux/amd64'
     }
     singularity {
         singularity.enabled     = true


### PR DESCRIPTION
Fixing error: `The user value contains invalid characters. Enter a value that matches the pattern ^([a-z0-9_][a-z0-9_-]{0,30})$`
