### PR TITLE
Fix design matrix bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix cutadapt 3' and 5' no such variable found bug ([#187](https://github.com/nf-core/crisprseq/pull/187))
-- Fix design matrix bug that introduced dots instead of a hyphen
+- Fix design matrix bug that introduced dots instead of a hyphen ([#190](https://github.com/nf-core/crisprseq/pull/190))
+- Make output of FluteMLE optional as when some pathways produce bugs some channels are then empty ([#190](https://github.com/nf-core/crisprseq/pull/190))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix cutadapt 3' and 5' no such variable found bug ([#187](https://github.com/nf-core/crisprseq/pull/187))
+- Fix design matrix bug that introduced dots instead of a hyphen
 
 ### Deprecated
 

--- a/modules/local/mageck/flutemle.nf
+++ b/modules/local/mageck/flutemle.nf
@@ -12,11 +12,11 @@ process MAGECK_FLUTEMLE {
     tuple val(meta), path(gene_summary)
 
     output:
-    tuple val(meta), path("MAGeCKFlute_*/Enrichment/*") , emit: enrich, optional: true
-    tuple val(meta), path("MAGeCKFlute_*/QC/*")         , emit: qc, optional: true
-    tuple val(meta), path("MAGeCKFlute_*/Selection/*")  , emit: select, optional: true
+    tuple val(meta), path("MAGeCKFlute_*/Enrichment/*") , emit: enrich     , optional: true
+    tuple val(meta), path("MAGeCKFlute_*/QC/*")         , emit: qc         , optional: true
+    tuple val(meta), path("MAGeCKFlute_*/Selection/*")  , emit: select     , optional: true
     tuple val(meta), path("MAGeCKFlute_*/PathwayView/*"), emit: pathwayview, optional: true
-    path "versions.yml"                                 , emit: versions, optional: true
+    path "versions.yml"                                 , emit: versions   , optional: true
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/mageck/flutemle.nf
+++ b/modules/local/mageck/flutemle.nf
@@ -12,11 +12,11 @@ process MAGECK_FLUTEMLE {
     tuple val(meta), path(gene_summary)
 
     output:
-    tuple val(meta), path("MAGeCKFlute_*/Enrichment/*") , emit: enrich
-    tuple val(meta), path("MAGeCKFlute_*/QC/*")         , emit: qc
-    tuple val(meta), path("MAGeCKFlute_*/Selection/*")  , emit: select
-    tuple val(meta), path("MAGeCKFlute_*/PathwayView/*"), emit: pathwayview
-    path "versions.yml"                                 , emit: versions
+    tuple val(meta), path("MAGeCKFlute_*/Enrichment/*") , emit: enrich, optional: true
+    tuple val(meta), path("MAGeCKFlute_*/QC/*")         , emit: qc, optional: true
+    tuple val(meta), path("MAGeCKFlute_*/Selection/*")  , emit: select, optional: true
+    tuple val(meta), path("MAGeCKFlute_*/PathwayView/*"), emit: pathwayview, optional: true
+    path "versions.yml"                                 , emit: versions, optional: true
 
     when:
     task.ext.when == null || task.ext.when

--- a/modules/local/matricescreation.nf
+++ b/modules/local/matricescreation.nf
@@ -33,6 +33,9 @@ process MATRICESCREATION {
                                 dimnames = list(all_samples,
                                                 c("Samples", "baseline",
                                                     name))))
+    # R automatically converts "-" to "." in the column names
+    # so here we re-assign the column names to keep the dashes defined by the user
+    colnames(design_matrix) <- c("Samples", "baseline", name)
 
     # Set baseline and treatment values in the design matrix
     design_matrix[, "Samples"] <- rownames(design_matrix)
@@ -40,7 +43,7 @@ process MATRICESCREATION {
     design_matrix[treatment_samples, name] <- 1
     design_matrix[treatment_samples, paste0(gsub(',', '_', '$meta.treatment'),"_vs_",gsub(",","_",'$meta.reference'))] <- 1
 
-    colnames(design_matrix) <- c("Samples", "baseline", name)
+
     # Print the design matrix to a file
     output_file <- paste0(gsub(',', '_', '$meta.treatment' ),"_vs_",gsub(",","_",'$meta.reference'),".txt")
     write.table(design_matrix, output_file, sep = "\t", quote = FALSE, row.names=FALSE)

--- a/modules/local/matricescreation.nf
+++ b/modules/local/matricescreation.nf
@@ -40,6 +40,7 @@ process MATRICESCREATION {
     design_matrix[treatment_samples, name] <- 1
     design_matrix[treatment_samples, paste0(gsub(',', '_', '$meta.treatment'),"_vs_",gsub(",","_",'$meta.reference'))] <- 1
 
+    colnames(design_matrix) <- c("Samples", "baseline", name)
     # Print the design matrix to a file
     output_file <- paste0(gsub(',', '_', '$meta.treatment' ),"_vs_",gsub(",","_",'$meta.reference'),".txt")
     write.table(design_matrix, output_file, sep = "\t", quote = FALSE, row.names=FALSE)


### PR DESCRIPTION
The bug I am currently having is due to dashes in potential sample names. Anything with a "-" in the sample name is converted to a dot in matrix and table creation in R and I haven't found a workaround except explicitely renaming the columns afterwards.
I could also rename the column names temporarily when i create the design_matrix and then rename with a comment, i just don't find anything very elegant sofar..

    design_matrix <- data.frame(matrix(0, nrow = length(all_samples), ncol = 3, dimnames = list(all_samples, c("temp1", "temp2", temp3))))