### PR TITLE
Fix crisprcleanr input file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix cutadapt 3' and 5' no such variable found bug ([#187](https://github.com/nf-core/crisprseq/pull/187))
 - Fix design matrix bug that introduced dots instead of a hyphen ([#190](https://github.com/nf-core/crisprseq/pull/190))
 - Make output of FluteMLE optional as when some pathways produce bugs some channels are then empty ([#190](https://github.com/nf-core/crisprseq/pull/190))
-- Fix a typo in crisprcleanr/normalize, when a user inputs a file
+- Fix a typo in crisprcleanr/normalize, when a user inputs a file ([#192](https://github.com/nf-core/crisprseq/pull/192))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix cutadapt 3' and 5' no such variable found bug ([#187](https://github.com/nf-core/crisprseq/pull/187))
 - Fix design matrix bug that introduced dots instead of a hyphen ([#190](https://github.com/nf-core/crisprseq/pull/190))
 - Make output of FluteMLE optional as when some pathways produce bugs some channels are then empty ([#190](https://github.com/nf-core/crisprseq/pull/190))
+- Fix a typo in crisprcleanr/normalize, when a user inputs a file
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -126,15 +126,15 @@ Main developers:
 We thank the following people for their extensive assistance in the development of this pipeline:
 
 - [@alan-tracey](https://github.com/alan-tracey)
+- [@bolenala](https://github.com/bolenala)
 - [@ggabernet](https://github.com/ggabernet)
 - [@jianhong](https://github.com/jianhong)
+- [@joannakraw](https://github.com/joannakraw)
 - [@mashehu](https://github.com/mashehu)
+- [@metinyazar](https://github.com/metinyazar)
 - [@msanvicente](https://github.com/msanvicente)
 - [@mschaffer-incyte](https://github.com/mschaffer-incyte)
 - [@SusiJo](https://github.com/SusiJo)
-- [@joannakraw](https://github.com/joannakraw)
-- [@metinyazar](https://github.com/metinyazar)
-- [@bolenala](https://github.com/bolenala)
 
 ## Contributions and Support
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ We thank the following people for their extensive assistance in the development 
 - [@SusiJo](https://github.com/SusiJo)
 - [@joannakraw](https://github.com/joannakraw)
 - [@metinyazar](https://github.com/metinyazar)
-- [@metinyazar](https://github.com/metinyazar)
 - [@bolenala](https://github.com/bolenala)
 
 ## Contributions and Support

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ We thank the following people for their extensive assistance in the development 
 - [@SusiJo](https://github.com/SusiJo)
 - [@joannakraw](https://github.com/joannakraw)
 - [@metinyazar](https://github.com/metinyazar)
+- [@metinyazar](https://github.com/metinyazar)
+- [@bolenala](https://github.com/bolenala)
 
 ## Contributions and Support
 

--- a/modules/nf-core/crisprcleanr/normalize/crisprcleanr-normalize.diff
+++ b/modules/nf-core/crisprcleanr/normalize/crisprcleanr-normalize.diff
@@ -1,4 +1,7 @@
 Changes in module 'nf-core/crisprcleanr/normalize'
+'modules/nf-core/crisprcleanr/normalize/environment.yml' is unchanged
+'modules/nf-core/crisprcleanr/normalize/meta.yml' is unchanged
+Changes in 'crisprcleanr/normalize/main.nf':
 --- modules/nf-core/crisprcleanr/normalize/main.nf
 +++ modules/nf-core/crisprcleanr/normalize/main.nf
 @@ -8,12 +8,15 @@
@@ -18,7 +21,7 @@ Changes in module 'nf-core/crisprcleanr/normalize'
      path "versions.yml",                       emit: versions
  
      when:
-@@ -26,20 +29,48 @@
+@@ -26,20 +29,49 @@
      """
      #!/usr/bin/env Rscript
      library(CRISPRcleanR)
@@ -51,7 +54,8 @@ Changes in module 'nf-core/crisprcleanr/normalize'
 +        rownames(library) = library[,1]
 +        library = library[order(rownames(library)),]
 +        library = library[,-1]
-+        count_file_to_normalize <- count_file
++        names(count_file)[names(count_file) == 'Gene'] <- 'gene'
++        count_file_to_normalize <- count_file %>% dplyr::select(sgRNA, gene, everything())
 +        }
 +
 +    normANDfcs <- ccr.NormfoldChanges(Dframe=count_file_to_normalize,saveToFig = FALSE,min_reads=${min_reads},EXPname="${prefix}", libraryAnnotation=library,display=FALSE)

--- a/modules/nf-core/crisprcleanr/normalize/main.nf
+++ b/modules/nf-core/crisprcleanr/normalize/main.nf
@@ -55,7 +55,8 @@ process CRISPRCLEANR_NORMALIZE {
         rownames(library) = library[,1]
         library = library[order(rownames(library)),]
         library = library[,-1]
-        count_file_to_normalize <- count_file
+        names(count_file)[names(count_file) == 'Gene'] <- 'gene'
+        count_file_to_normalize <- count_file %>% dplyr::select(sgRNA, gene, everything())
         }
 
     normANDfcs <- ccr.NormfoldChanges(Dframe=count_file_to_normalize,saveToFig = FALSE,min_reads=${min_reads},EXPname="${prefix}", libraryAnnotation=library,display=FALSE)


### PR DESCRIPTION
In the process CRISPRCLEANR_NORMALIZE I use a custom library file which results in running the code in the else loop. The column name of the count_file is "Gene" and not "gene" resulting in an error. @bolenala mentions it here : https://github.com/nf-core/crisprseq/issues/161 and provides a fix :) 