### PR TITLE
accept .csv for library parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Allow csv files in the validation of the `--library` parameter ([#229](https://github.com/nf-core/crisprseq/pull/229)) 
+- Allow csv files in the validation of the `--library` parameter ([#229](https://github.com/nf-core/crisprseq/pull/229))
 
 ### General
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Allow csv files in the validation of the `--library` parameter ([#229](https://github.com/nf-core/crisprseq/pull/229)) 
+
 ### General
 
 ## [v2.3.0 - Lime Nightingale](https://github.com/nf-core/crisprseq/releases/tag/2.3.0) - [08.11.2024]

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -161,11 +161,11 @@
                 "library": {
                     "type": "string",
                     "format": "file-path",
-                    "pattern": "^\\S+\\.(tsv|txt)$",
+                    "pattern": "^\\S+\\.(tsv|txt|csv)$",
                     "mimetype": "text/tsv",
                     "exists": true,
                     "fa_icon": "far fa-address-book",
-                    "description": "sgRNA and targetting genes, tab separated"
+                    "description": "sgRNA and targetting genes, tab or comma separated"
                 },
                 "five_prime_adapter": {
                     "type": "string",


### PR DESCRIPTION
Changes of the json schema to address issue #228.
The `library` entry of the schema has been modified in this way:

    "library": {
         ...
        "pattern": "^\\S+\\.(tsv|txt|csv)$",
        ...
        "description": "sgRNA and targetting genes, tab or comma separated"

 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/crisprseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/crisprseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
