### PR TITLE
new parameters added to the trimming commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add an acknowlodgement to Hitselection method ([#222]https://github.com/nf-core/crisprseq/pull/222)
+- Added parameters specifying additional arguments for the cutadapt command line ([#237](https://github.com/nf-core/crisprseq/pull/237))
 
 ### Fixed
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -237,7 +237,7 @@ process {
     }
 
     withName: CUTADAPT_FIVE_PRIME {
-        ext.args = "-g ${params.five_prime_adapter}"
+        ext.args = "-g ${params.five_prime_adapter} ${params.extra_cutadapt_five_prime_args ?: ''}"
         publishDir = [
             path: { "${params.outdir}/preprocessing/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
             mode: params.publish_dir_mode,
@@ -246,7 +246,7 @@ process {
     }
 
     withName: CUTADAPT_THREE_PRIME {
-        ext.args = "-a ${params.three_prime_adapter}"
+        ext.args = "-a ${params.three_prime_adapter} ${params.extra_cutadapt_three_prime_args ?: ''}"
         publishDir = [
             path: { "${params.outdir}/preprocessing/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
             mode: params.publish_dir_mode,

--- a/docs/usage/screening.md
+++ b/docs/usage/screening.md
@@ -44,7 +44,7 @@ An [example samplesheet](https://github.com/nf-core/test-datasets/blob/crisprseq
 
 ### cutadapt
 
-MAGeCK count which is the main alignment software used is normally able to automatically determine the trimming length and sgRNA length, in most cases. Therefore, you don't need to go to this step unless MAGeCK fails to do so by itself. If the nucleotide length in front of sgRNA varies between different reads, you can use cutadapt to remove the adaptor sequences by using the flag `--five_prime_adapter` or `--three_prime_adapter` .
+MAGeCK count which is the main alignment software used is normally able to automatically determine the trimming length and sgRNA length, in most cases. Therefore, you don't need to go to this step unless MAGeCK fails to do so by itself. If the nucleotide length in front of sgRNA varies between different reads, you can use cutadapt to remove the adaptor sequences by using the flag `--five_prime_adapter` or `--three_prime_adapter` . Additional arguments can be passed to cutadapt by using the parameters `extra_cutadapt_five_prime_args` and `extra_cutadapt_three_prime_args`.
 
 ### bowtie2
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,6 +36,8 @@ params {
     drugz_remove_genes         = null
     hitselection               = false
     hit_selection_iteration_nb = 1000
+    extra_cutadapt_five_prime_args = null
+    extra_cutadapt_three_prime_args = null
     // Pipeline steps
     overrepresented            = false
     umi_clustering             = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -171,9 +171,19 @@
                     "type": "string",
                     "description": "Sequencing adapter sequence to use for trimming on the 5' end"
                 },
+                "extra_cutadapt_five_prime_args": {
+                    "type": "string",
+                    "description": "Extra arguments to pass to the cutadapt command for trimming on the 5' end.",
+                    "fa_icon": "fas fa-plus"
+                },
                 "three_prime_adapter": {
                     "type": "string",
                     "description": "Sequencing adapter sequence to use for trimming on the 3' end"
+                },
+                "extra_cutadapt_three_prime_args": {
+                    "description": "Extra arguments to pass to the cutadapt command for trimming on the 3' end.",
+                    "type": "string",
+                    "fa_icon": "fas fa-plus"
                 },
                 "bowtie": {
                     "type": "boolean",


### PR DESCRIPTION
This PR implements a new feature I requested in issue #231, introducing parameters that allow specifying additional arguments for the cutadapt command line.

Two separate parameters are provided: one for 5' trimming and one for 3' trimming, as trimming requirements for each read end may vary depending on the experimental setup.

Marking this PR as draft, as further work is needed to:
- Test the implementation
- Update the parameter schema

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/crisprseq/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/crisprseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
