### PR TITLE
samples instead of conditions in contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed link to example contranst file in the usage documentation ([#236](https://github.com/nf-core/crisprseq/pull/236))
 - Fixed bug in Bowtie alignment for guide libraries ([#247](https://github.com/nf-core/crisprseq/pull/247))
 - Sample names instead of conditions are used in the MAGeCK output ([#252](https://github.com/nf-core/crisprseq/pull/252))
+- Supports precomputed count matrices without a samplesheet, interpreting contrast file entries as samples instead of conditions ([#260](https://github.com/nf-core/crisprseq/pull/260))
 
 ### General
 

--- a/docs/usage/screening.md
+++ b/docs/usage/screening.md
@@ -82,7 +82,7 @@ BAGEL2 and DrugZ. You can run any of these modules by providing a contrast file 
 - `--drugz` for DrugZ
 - `--bagel2` for BAGEL2
 
-The contrast file must contain the headers "reference" and "treatment". These two columns should be separated with a semicolon (;) and contain the `csv` extension. You can also integrate several samples/conditions by comma-separating them in each column. Please find an example below:
+The contrast file must contain the headers "reference" and "treatment". These two columns should be separated with a semicolon (;) and contain the `csv` extension. You can also integrate several conditions by comma-separating them in each column. Please find an example below:
 
 | reference         | treatment             |
 | ----------------- | --------------------- |
@@ -90,6 +90,8 @@ The contrast file must contain the headers "reference" and "treatment". These tw
 | control1,control2 | treatment1,treatment2 |
 
 A full example can be found [here](https://raw.githubusercontent.com/nf-core/test-datasets/crisprseq/testdata/rra_contrasts.txt).
+
+When providing a precomputed count matrix with `--count_table`, the contrast file must list sample names (not conditions). Use the exact sample labels from the count table header, and if you want to group multiple samples, separate them with commas within each column.
 
 #### Venn diagram
 

--- a/subworkflows/local/utils_nfcore_crisprseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_crisprseq_pipeline/main.nf
@@ -162,7 +162,7 @@ workflow INITIALISATION_CHANNEL_CREATION_SCREENING {
     ch_hgnc = Channel.fromPath("$projectDir/assets/hgnc_complete_set.txt", checkIfExists: true).first()
 
     if(params.mle_control_sgrna) {
-        ch_mle_control_sgrna = Channel.fromPath(params.mle_control_sgrna)
+        ch_mle_control_sgrna = Channel.value(file(params.mle_control_sgrna, checkIfExists: true))
     } else {
         ch_mle_control_sgrna = []
     }

--- a/workflows/crisprseq_screening.nf
+++ b/workflows/crisprseq_screening.nf
@@ -235,35 +235,45 @@ workflow CRISPRSEQ_SCREENING {
 
     if (params.contrasts) {
 
-        // Map each condition in the samplesheet to the list of sample ids belonging to that condition
-        ch_samplesheet
-            .map { meta, _fastq -> [meta.condition, meta] }
-            .groupTuple(by: 0) // Group by condition
-            .map { condition, metas -> [condition, metas.collect { it.id }]}
-            .set { ch_samplesheet_conditions } // tuples (condition, [sample_id1, sample_id2, ...])
-
         // Map each contrast in the contrasts file to a the list of treatment / reference conditions to compare
         Channel
             .fromPath(params.contrasts)
             .splitCsv(header:true, sep:';')
             .map { line -> [
                     id: "${line.treatment.replace(",", "_")}_vs_${line.reference.replace(",", "_")}",
-                    treatment: line.treatment.split(','),
-                    reference: line.reference.split(',')
+                    treatment: line.treatment,
+                    reference: line.reference
                 ]
             }
             .set { ch_contrasts } // maps [id: "...", treatment: [cond1, ...], reference: [cond2, ...]]
 
-        // Map each contrast to the corresponding sample ids for treatment and reference, and then combine with the count table
-        ch_contrasts
-            .combine(ch_samplesheet_conditions.collect(flat: false).map{ it -> [it] }) // combine each contrast element with a single-element list containing all (condition, [sample_ids]) tuples
-            .map { contrast_meta, all_conditions ->
-                def treatment_samples = all_conditions.find { it[0] in contrast_meta.treatment }  // Find samples for each condition
-                def reference_samples = all_conditions.find { it[0] in contrast_meta.reference }
-                return [ id: contrast_meta.id,  treatment: treatment_samples[1].join(","), reference: reference_samples[1].join(",") ]
-            } // emits maps: [id: "...", treatment: "sample1,sample2", reference: "sample3,sample4"]
-            .combine(ch_counts)
-            .set{ ch_contrasts_counts } // tuples (contrast_map, counts) with each contrast combined with the count table
+        if (params.count_table) {
+
+            // When the count table is provided, we assume that the sample IDs in the contrasts file correspond to the sample IDs in the count table
+            ch_contrasts
+                .combine(ch_counts)
+                .set{ ch_contrasts_counts } // tuples (contrast_map, counts) with each contrast combined with the count table
+
+        } else {
+
+            // Map each condition in the samplesheet to the list of sample ids belonging to that condition
+            ch_samplesheet
+                .map { meta, _fastq -> [meta.condition, meta] }
+                .groupTuple(by: 0) // Group by condition
+                .map { condition, metas -> [condition, metas.collect { it.id }]}
+                .set { ch_samplesheet_conditions } // tuples (condition, [sample_id1, sample_id2, ...])
+
+            // Map each contrast to the corresponding sample ids for treatment and reference, and then combine with the count table
+            ch_contrasts
+                .combine(ch_samplesheet_conditions.collect(flat: false).map{ it -> [it] }) // combine each contrast element with a single-element list containing all (condition, [sample_ids]) tuples
+                .map { contrast_meta, all_conditions ->
+                    def treatment_samples = all_conditions.find { it[0] in contrast_meta.treatment.split(',') }  // Find samples for each condition
+                    def reference_samples = all_conditions.find { it[0] in contrast_meta.reference.split(',') }
+                    return [ id: contrast_meta.id,  treatment: treatment_samples[1].join(","), reference: reference_samples[1].join(",") ]
+                } // emits maps: [id: "...", treatment: "sample1,sample2", reference: "sample3,sample4"]
+                .combine(ch_counts)
+                .set{ ch_contrasts_counts } // tuples (contrast_map, counts) with each contrast combined with the count table
+        }
     }
 
     if (params.rra) {


### PR DESCRIPTION
When running a MLE analysis from a precomputed count matrix and a contrast file, the pipeline does not work because in the changes of #252 the condition labels in the contrast file should be mapped to sample names using the samplesheet, but the samplesheet when the count matrix is provided can be omitted. 

This can be tested with an input like:
```
count_table: "https://raw.githubusercontent.com/nf-core/test-datasets/crisprseq/testdata/count_table.tsv"
analysis: 'screening'
contrasts: "https://raw.githubusercontent.com/nf-core/test-datasets/crisprseq/testdata/rra_contrasts.txt"
outdir: "output"
mle: true
```

In this PR, the issue is fixed by assuming that in this case the contrast file contains sample labels instead of condition labels, hence omitting the mapping from conditions to samples.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/crisprseq/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/crisprseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
